### PR TITLE
Setting python version for sonar analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=marcelorodrigo_zwift-to-garmin
 sonar.organization=marcelorodrigo
 sonar.projectName=zwift-to-garmin
-sonar.python.version=3.13.1
+sonar.python.version=3.13
 
 # Test execution reports
 sonar.python.xunit.reportPath=test-results.xml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tooling configuration to target Python 3.13.1 for static analysis, improving consistency with the current runtime and development environment.
  * Removed a deprecated project naming setting from the analysis configuration.
  * No changes to application features or behavior; this update does not affect users directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->